### PR TITLE
Fixed an issue with the web3 service

### DIFF
--- a/addon/services/web3.js
+++ b/addon/services/web3.js
@@ -8,7 +8,7 @@ export default Service.extend({
 
   setup(provider) {
     let web3Instance = new Web3(provider);
-    this.set('web3Instance', web3);
+    this.set('web3Instance', web3Instance);
     return web3Instance;
   },
 


### PR DESCRIPTION
I'm experiencing an error: "Cannot read property 'contract' of undefined" on line 21 of this file because `this.get('web3Instance')` is not returning the correct object. I believe this is the fix.